### PR TITLE
Fix issue where memo that is not synchronized yet may be removed when synchronizing

### DIFF
--- a/lib/memo_store_merger.dart
+++ b/lib/memo_store_merger.dart
@@ -40,11 +40,15 @@ class MemoStoreMerger {
         // Memo is in fromMemoStore. Do not remove.
         newMemos.add(memo);
       } else {
-        final toLastModified = DateTime.fromMillisecondsSinceEpoch(memo.lastModified).toUtc();
-        final toLastMerged = DateTime.fromMillisecondsSinceEpoch(toMemoStore.lastMerged).toUtc();
+        final toLastModified =
+            DateTime.fromMillisecondsSinceEpoch(memo.lastModified).toUtc();
+        final toLastMerged =
+            DateTime.fromMillisecondsSinceEpoch(toMemoStore.lastMerged).toUtc();
         if (toLastModified.isBefore(toLastMerged)) {
           // Memos is already syncrhonized and removed from fromMemoStore.
-          final fromLastMerged = DateTime.fromMillisecondsSinceEpoch(fromMemoStore.lastMerged).toUtc();
+          final fromLastMerged =
+              DateTime.fromMillisecondsSinceEpoch(fromMemoStore.lastMerged)
+                  .toUtc();
           if (fromLastMerged.isBefore(toLastModified)) {
             // Memo is updated after last merged. Do not remove.
             newMemos.add(memo);

--- a/test/memo_store_merger_test.dart
+++ b/test/memo_store_merger_test.dart
@@ -15,7 +15,7 @@ void main() {
     });
 
     test(
-        'MemoStoreMerger should keep memos in to memo store if it is modified after last merged.',
+        'MemoStoreMerger should keep memos in toMemoStore if it is modified after last merged.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();
@@ -31,7 +31,7 @@ void main() {
     });
 
     test(
-        'MemoStoreMerger should remove memos in toMemoStore if it is synchronized and modified before fromMemoStore.lastMerged.',
+        'MemoStoreMerger should remove memos in toMemoStore if it is synchronized and modified before last merged.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();
@@ -64,7 +64,7 @@ void main() {
       expect(toMemoStore.memos.length, 1);
     });
 
-    test('MemoStoreMerger should move memos that are only in from memo store.',
+    test('MemoStoreMerger should move memos that are only in fromMemoStore.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();
@@ -108,7 +108,7 @@ void main() {
       expect(toMemo.text.contains('This is a from memo.'), true);
     });
 
-    test('MemoStoreMerger should not update memos if to memos are modified.',
+    test('MemoStoreMerger should not update memos if toMemos are modified.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();
@@ -128,7 +128,7 @@ void main() {
     });
 
     test(
-        'MemoStoreMerger should make conficted memos if both memos in from and to memo store are modified.',
+        'MemoStoreMerger should make conficted memos if both memos in fromMemoStore and toMemoStore are modified.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();
@@ -147,7 +147,7 @@ void main() {
     });
 
     test(
-        'MemoStoreMerger should not make conficted memos if both memos in from and to memo store are modified but these texts are same.',
+        'MemoStoreMerger should not make conficted memos if both memos in fromMemoStore and toMemoStore are modified but these texts are same.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();
@@ -188,7 +188,7 @@ void main() {
     });
 
     test(
-        'MemoStoreMerger should merge memo\'s tags if both memos in from and to memo store are modified.',
+        'MemoStoreMerger should merge memo\'s tags if both memos in fromMemoStore and toMemoStore are modified.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();

--- a/test/memo_store_merger_test.dart
+++ b/test/memo_store_merger_test.dart
@@ -31,7 +31,25 @@ void main() {
     });
 
     test(
-        'MemoStoreMerger should remove memos in to memo store if it is modified before last merged.',
+        'MemoStoreMerger should remove memos in toMemoStore if it is synchronized and modified before fromMemoStore.lastMerged.',
+        () {
+      final toMemoStore = MemoStore();
+      final fromMemoStore = MemoStore();
+      final memo = Memo();
+      memo.text = 'This is a to memo.';
+      sleep(const Duration(milliseconds: 1));
+      toMemoStore.lastMerged = DateTime.now().millisecondsSinceEpoch;
+      sleep(const Duration(milliseconds: 1));
+      fromMemoStore.lastMerged = DateTime.now().millisecondsSinceEpoch;
+      toMemoStore.addMemo(memo);
+      expect(toMemoStore.memos.length, 1);
+      final memoStoreMerger = MemoStoreMerger(toMemoStore, fromMemoStore);
+      memoStoreMerger.execute();
+      expect(toMemoStore.memos.length, 0);
+    });
+
+    test(
+        'MemoStoreMerger should not remove memos in toMemoStore if it is not synchronized.',
         () {
       final toMemoStore = MemoStore();
       final fromMemoStore = MemoStore();
@@ -43,7 +61,7 @@ void main() {
       expect(toMemoStore.memos.length, 1);
       final memoStoreMerger = MemoStoreMerger(toMemoStore, fromMemoStore);
       memoStoreMerger.execute();
-      expect(toMemoStore.memos.length, 0);
+      expect(toMemoStore.memos.length, 1);
     });
 
     test('MemoStoreMerger should move memos that are only in from memo store.',


### PR DESCRIPTION
In related issue #78, fixed issue where memo that is not synchronized yet may be removed when synchronizing.