### PR TITLE
Use Cupertino's activity indicator when processing

### DIFF
--- a/lib/common_uis.dart
+++ b/lib/common_uis.dart
@@ -78,11 +78,21 @@ class TextTheme {
 
 /// Shows dialogs to indicate progressing.
 void showProgressIndicatorDialog(BuildContext context) {
+  final platform = LocalPlatform();
+  late final Widget indicator;
+  if (!platform.isApple) {
+    indicator = const CircularProgressIndicator();
+  } else {
+    indicator = const CupertinoActivityIndicator(
+      color: Colors.white,
+      radius: 20.0,
+    );
+  }
   showDialog(
     context: context,
     builder: (context) {
-      return const Center(
-        child: const CircularProgressIndicator(),
+      return Center(
+        child: indicator,
       );
     },
     barrierDismissible: false,

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -54,4 +54,7 @@ extension AbstractProviding on Platform {
 
   /// Returns whether platform is mobile or not.
   bool get isMobile => isAndroid || isIOS;
+
+  /// Returns whether platform is developed by Apple or not.
+  bool get isApple => isMacOS || isIOS;
 }


### PR DESCRIPTION
In related to issue #124, used Cupertino's activity indicator when processing.