### PR TITLE
Update tests to avoid deprecation of save-state and save-output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Cache Flutter dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /opt/hostedtoolcache/flutter
           key: ${{ runner.OS }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}


### PR DESCRIPTION
In related to issue #213, updated tests to avoid deprecation of save-state and save-output.