### PR TITLE
Show close button in editing page when in small screen mode

### DIFF
--- a/lib/editing_page.dart
+++ b/lib/editing_page.dart
@@ -72,10 +72,10 @@ class _EditingPageState extends State<EditingPage> {
       title = localizations.editAMemo;
     }
     late Widget leading;
-    if (hasLargeScreen() && widget.memo == null) {
-      leading = CloseButton();
-    } else {
+    if (hasLargeScreen() && widget.memo != null) {
       leading = BackButton();
+    } else {
+      leading = CloseButton();
     }
     return WillPopScope(
       onWillPop: _confirm,


### PR DESCRIPTION
In related to issue #217, showed close button in editing page when in small screen mode.