### PR TITLE
Add ordered list support for Markdown parser

### DIFF
--- a/lib/markdown_parser.dart
+++ b/lib/markdown_parser.dart
@@ -113,8 +113,8 @@ class MarkdownParser {
       _parseHeadlineLarge,
       _parseHeadlineMedium,
       _parseHeadlineSmall,
-      _parseUnorderdList,
-      _parseOrderdList,
+      _parseUnorderedList,
+      _parseOrderedList,
       _parseStrikethrough,
       _parseChechboxChecked,
       _parseChechboxUnchecked,
@@ -246,7 +246,7 @@ class MarkdownParser {
                   width: 15.0,
                   child: Align(
                     alignment: Alignment.centerRight,
-                    child: Text('${orderedListNumber}. '),
+                    child: Text('$orderedListNumber. '),
                   ),
                 ),
                 Flexible(
@@ -329,7 +329,7 @@ class MarkdownParser {
     return (line, false);
   }
 
-  (String, bool) _parseUnorderdList(String line) {
+  (String, bool) _parseUnorderedList(String line) {
     final regExp = RegExp(r'^ *[\+\-\*] ');
     final match = regExp.firstMatch(line);
     if (match != null) {
@@ -346,7 +346,7 @@ class MarkdownParser {
     return (line, false);
   }
 
-  (String, bool) _parseOrderdList(String line) {
+  (String, bool) _parseOrderedList(String line) {
     final regExp = RegExp(r'^ *\d+[.)] ');
     final match = regExp.firstMatch(line);
     if (match != null) {

--- a/lib/markdown_parser.dart
+++ b/lib/markdown_parser.dart
@@ -33,6 +33,7 @@ enum _LineKind {
   headlineMedium,
   headlineSmall,
   unorderedList,
+  orderedList,
 }
 
 enum _SpanState {
@@ -112,6 +113,7 @@ class MarkdownParser {
       _parseHeadlineMedium,
       _parseHeadlineSmall,
       _parseUnorderdList,
+      _parseOrderdList,
       _parseStrikethrough,
       _parseChechboxChecked,
       _parseChechboxUnchecked,
@@ -230,6 +232,29 @@ class MarkdownParser {
             );
             break;
 
+          case _LineKind.orderedList:
+            var listLevel = listLevels[processedLine.indent] ?? 0;
+            widget = Row(
+              children: [
+                SizedBox(
+                  width: 20.0,
+                  child: const Align(
+                    alignment: Alignment.centerRight,
+                    child: Text('1.'),
+                  ),
+                ),
+                Flexible(
+                  child: RichText(
+                    text: TextSpan(
+                      style: textTheme.bodyMedium,
+                      children: processedLine.spans,
+                    ),
+                  ),
+                ),
+              ],
+            );
+            break;
+
           default:
             break;
         }
@@ -307,6 +332,23 @@ class MarkdownParser {
         line = line.replaceFirst(regExp, '');
         _processedLine.indent = string.length - 2;
         _processedLine.lineKind = _LineKind.unorderedList;
+
+        return (line, true);
+      }
+    }
+
+    return (line, false);
+  }
+
+  (String, bool) _parseOrderdList(String line) {
+    final regExp = RegExp(r'^ *\d+[.)] ');
+    final match = regExp.firstMatch(line);
+    if (match != null) {
+      final string = match.group(0);
+      if (string != null) {
+        line = line.replaceFirst(regExp, '');
+        _processedLine.indent = 0;
+        _processedLine.lineKind = _LineKind.orderedList;
 
         return (line, true);
       }

--- a/lib/markdown_parser.dart
+++ b/lib/markdown_parser.dart
@@ -45,6 +45,7 @@ enum _SpanState {
 }
 
 class _ProcessedLine {
+  // TODO: Add paragraph started flag?
   var indent = 0;
   var lineKind = _LineKind.body;
   var spans = <InlineSpan>[];
@@ -156,6 +157,7 @@ class MarkdownParser {
 
     final widgets = <Widget>[];
     var previousLineKind = _LineKind.none;
+    var orderedListNumber = 1;
     for (final processedLine in processedLines) {
       if (_paragraphStarted && previousLineKind == _LineKind.body) {
         widgets.add(const SizedBox(height: 10.0));
@@ -233,14 +235,18 @@ class MarkdownParser {
             break;
 
           case _LineKind.orderedList:
-            var listLevel = listLevels[processedLine.indent] ?? 0;
+            if (previousLineKind != _LineKind.orderedList) {
+              orderedListNumber = 1;
+            } else {
+              orderedListNumber++;
+            }
             widget = Row(
               children: [
                 SizedBox(
-                  width: 20.0,
-                  child: const Align(
+                  width: 15.0,
+                  child: Align(
                     alignment: Alignment.centerRight,
-                    child: Text('1.'),
+                    child: Text('${orderedListNumber}. '),
                   ),
                 ),
                 Flexible(

--- a/test/markdown_parser_test.dart
+++ b/test/markdown_parser_test.dart
@@ -136,6 +136,20 @@ void main() {
       expect(row.children[1] is Flexible, true);
     });
 
+    testWidgets('MarkdownParser should create widgets for ordered lists.',
+        (WidgetTester tester) async {
+      await init(tester);
+      final context = tester.element(find.text('This is a test.'));
+      final parser = MarkdownParser(context, '1. Hello, World!');
+      parser.execute();
+      final contents = parser.contents;
+      final column = contents as Column;
+      final widget = column.children[0];
+      final row = widget as Row;
+      expect(row.children[0] is SizedBox, true);
+      expect(row.children[1] is Flexible, true);
+    });
+
     testWidgets('MarkdownParser should create widgets for link texts.',
         (WidgetTester tester) async {
       await init(tester);


### PR DESCRIPTION
Added ordered list support for Markdown parser.
This closes #332.
