### PR TITLE
Reset scrolling position of viewing page when shown memo is updated

### DIFF
--- a/lib/viewing_page.dart
+++ b/lib/viewing_page.dart
@@ -56,9 +56,11 @@ class ViewingPage extends StatefulWidget {
 
 class _ViewingPageState extends State<ViewingPage>
     with TickerProviderStateMixin {
-  late final TextEditingController _textEditingController;
+  final _textEditingController = TextEditingController();
   late final AnimationController _animationController;
-  late Animation<Offset> _animation;
+  final _scrollController = ScrollController();
+  Animation<Offset> _animation =
+      const AlwaysStoppedAnimation<Offset>(Offset(0.0, 0.0));
   late Memo _memo;
   final _previousMemos = <Memo>[];
   var _fullScreen = false;
@@ -66,10 +68,8 @@ class _ViewingPageState extends State<ViewingPage>
   @override
   void initState() {
     super.initState();
-    _textEditingController = TextEditingController();
     _animationController = AnimationController(
         duration: const Duration(milliseconds: 300), vsync: this);
-    _animation = const AlwaysStoppedAnimation<Offset>(Offset(0.0, 0.0));
     _memo = widget.memo;
     _fullScreen = widget.fullScreen;
   }
@@ -389,7 +389,7 @@ class _ViewingPageState extends State<ViewingPage>
                       if (memo != null) {
                         if (memo != _memo) {
                           setState(() {
-                              error = true;
+                            error = true;
                           });
                         } else {
                           Navigator.of(context).pop(null);

--- a/lib/viewing_page.dart
+++ b/lib/viewing_page.dart
@@ -76,6 +76,7 @@ class _ViewingPageState extends State<ViewingPage>
 
   @override
   void dispose() {
+    _scrollController.dispose();
     _animationController.dispose();
     _textEditingController.dispose();
     super.dispose();
@@ -192,6 +193,7 @@ class _ViewingPageState extends State<ViewingPage>
           actions: actions,
         ),
         body: ListView(
+          controller: _scrollController,
           children: [
             ClipRect(
               child: SlideTransition(
@@ -496,6 +498,7 @@ class _ViewingPageState extends State<ViewingPage>
     }
     _previousMemos.add(_memo);
     _animateCard(_Direction.forward);
+    _scrollController.jumpTo(0.0);
     setState(() {
       _memo = memo;
     });
@@ -503,6 +506,7 @@ class _ViewingPageState extends State<ViewingPage>
 
   void _showPreviousMemo() {
     _animateCard(_Direction.backward);
+    _scrollController.jumpTo(0.0);
     setState(() {
       _memo = _previousMemos.last;
       _previousMemos.removeLast();


### PR DESCRIPTION
Reset scrolling position of viewing page when shown memo is updated.
This closes #388.
