### PR TITLE
Show memo name in app bar title of viewing page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -135,13 +135,6 @@
     "@linkedMemoIsNotFound": {
         "description": "Text for linked memo not found error dialog."
     },
-    "memoAtDateTime": "Memo at {dateTime}",
-    "@memoAtDateTime": {
-        "description": "Title for viewing page app bar",
-        "placeholders": {
-            "dateTime": {}
-        }
-    },
     "boundTags": "Tags: {tags}",
     "@boundTags": {
         "description": "Text for tags list tile",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -31,7 +31,6 @@
     "memoStoreOnTheGoogleDriveIsNotCompatible": "Google Drive上のメモストアに互換性がありません。このアプリをアップデートすることで問題が解決するかもしれません。",
     "memoNotFound": "メモが見つかりません",
     "linkedMemoIsNotFound": "リンク先のメモが見つかりません。",
-    "memoAtDateTime": "{dateTime}のメモ",
     "boundTags": "タグ: {tags}",
     "name": "名前: {name}",
     "viewingMode": "表示モード: {viewingMode}",

--- a/lib/viewing_page.dart
+++ b/lib/viewing_page.dart
@@ -189,7 +189,7 @@ class _ViewingPageState extends State<ViewingPage>
           leading: common_uis.hasLargeScreen()
               ? const CloseButton()
               : const BackButton(),
-          title: Text(localizations.memoAtDateTime(dateTime.toSmartString())),
+          title: Text(_memo.name),
           actions: actions,
         ),
         body: ListView(

--- a/test/viewing_page_test.dart
+++ b/test/viewing_page_test.dart
@@ -9,6 +9,7 @@ import 'package:tsukimisou/viewing_page.dart';
 
 Future<void> init(WidgetTester tester, Memo memo) async {
   memo.text = 'This is a test.';
+  memo.name = 'Test';
   await tester.pumpWidget(
     ChangeNotifierProvider(
       create: (context) => MemoStore(),
@@ -35,7 +36,7 @@ void main() {
       expect(find.byIcon(Icons.share), findsOneWidget);
       expect(find.byIcon(Icons.delete), findsOneWidget);
       expect(find.byIcon(Icons.edit), findsOneWidget);
-      expect(find.textContaining('Memo at'), findsOneWidget);
+      expect(find.textContaining('Test'), findsWidgets);
       expect(find.textContaining('This is a test.'), findsOneWidget);
       expect(find.textContaining('Updated:'), findsOneWidget);
       expect(find.textContaining('Tags:'), findsOneWidget);


### PR DESCRIPTION
Showed memo name in app bar title of viewing page.
This closes #340.
