### PR TITLE
Add setUpAll() and tearDownAll() callings for tests

### DIFF
--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -15,6 +15,10 @@ void main() {
     };
   });
 
+  tearDownAll(() {
+    Settings.sharedPreferencesCreatorHook = null;
+  });
+
   testWidgets('App widget smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(
       MultiProvider(
@@ -30,9 +34,5 @@ void main() {
     expect(find.byIcon(Icons.add), findsOneWidget);
     await tester.tap(find.byIcon(Icons.add));
     await tester.pump();
-  });
-
-  tearDownAll(() {
-    Settings.sharedPreferencesCreatorHook = null;
   });
 }

--- a/test/binding_tags_page_test.dart
+++ b/test/binding_tags_page_test.dart
@@ -19,54 +19,54 @@ Future<void> init(WidgetTester tester, Memo memo) async {
 
 void main() {
   group('BindingTagsPage', () {
-      setUpAll(() {
-          MemoStoreLocalSaver.constructorHook = (memoStore, path) {
-            return MemoStoreMockLocalSaver(memoStore, path);
-          };
-      });
+    setUpAll(() {
+      MemoStoreLocalSaver.constructorHook = (memoStore, path) {
+        return MemoStoreMockLocalSaver(memoStore, path);
+      };
+    });
 
-      tearDownAll(() {
-          MemoStoreLocalSaver.constructorHook = null;
-      });
+    tearDownAll(() {
+      MemoStoreLocalSaver.constructorHook = null;
+    });
 
-      testWidgets('BindingTagsPage should have specified widgets.',
+    testWidgets('BindingTagsPage should have specified widgets.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          memo.text = 'This is a test.';
-          memo.tags = ['a', 'b', 'c'];
-          await init(tester, memo);
-          expect(find.text('a'), findsOneWidget);
-          expect(find.text('b'), findsOneWidget);
-          expect(find.text('c'), findsOneWidget);
-          expect(find.text('d'), findsOneWidget);
-          expect(find.text('e'), findsOneWidget);
-          expect(find.text('f'), findsOneWidget);
-          expect(find.byIcon(Icons.check_circle), findsNWidgets(3));
-          expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(3));
-      });
+      final memo = Memo();
+      memo.text = 'This is a test.';
+      memo.tags = ['a', 'b', 'c'];
+      await init(tester, memo);
+      expect(find.text('a'), findsOneWidget);
+      expect(find.text('b'), findsOneWidget);
+      expect(find.text('c'), findsOneWidget);
+      expect(find.text('d'), findsOneWidget);
+      expect(find.text('e'), findsOneWidget);
+      expect(find.text('f'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle), findsNWidgets(3));
+      expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(3));
+    });
 
-      testWidgets('BindingTagsPage should add tags to memo.',
+    testWidgets('BindingTagsPage should add tags to memo.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          memo.text = 'This is a test.';
-          memo.tags = ['a', 'b', 'c'];
-          await init(tester, memo);
-          await tester.tap(find.text('d'));
-          await tester.pump();
-          expect(find.byIcon(Icons.check_circle), findsNWidgets(4));
-          expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(2));
-      });
+      final memo = Memo();
+      memo.text = 'This is a test.';
+      memo.tags = ['a', 'b', 'c'];
+      await init(tester, memo);
+      await tester.tap(find.text('d'));
+      await tester.pump();
+      expect(find.byIcon(Icons.check_circle), findsNWidgets(4));
+      expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(2));
+    });
 
-      testWidgets('BindingTagsPage should remove tags from memo.',
+    testWidgets('BindingTagsPage should remove tags from memo.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          memo.text = 'This is a test.';
-          memo.tags = ['a', 'b', 'c'];
-          await init(tester, memo);
-          await tester.tap(find.text('a'));
-          await tester.pump();
-          expect(find.byIcon(Icons.check_circle), findsNWidgets(2));
-          expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(4));
-      });
+      final memo = Memo();
+      memo.text = 'This is a test.';
+      memo.tags = ['a', 'b', 'c'];
+      await init(tester, memo);
+      await tester.tap(find.text('a'));
+      await tester.pump();
+      expect(find.byIcon(Icons.check_circle), findsNWidgets(2));
+      expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(4));
+    });
   });
 }

--- a/test/binding_tags_page_test.dart
+++ b/test/binding_tags_page_test.dart
@@ -18,51 +18,55 @@ Future<void> init(WidgetTester tester, Memo memo) async {
 }
 
 void main() {
-  MemoStoreLocalSaver.constructorHook = (memoStore, path) {
-    return MemoStoreMockLocalSaver(memoStore, path);
-  };
-
   group('BindingTagsPage', () {
-    testWidgets('BindingTagsPage should have specified widgets.',
-        (WidgetTester tester) async {
-      final memo = Memo();
-      memo.text = 'This is a test.';
-      memo.tags = ['a', 'b', 'c'];
-      await init(tester, memo);
-      expect(find.text('a'), findsOneWidget);
-      expect(find.text('b'), findsOneWidget);
-      expect(find.text('c'), findsOneWidget);
-      expect(find.text('d'), findsOneWidget);
-      expect(find.text('e'), findsOneWidget);
-      expect(find.text('f'), findsOneWidget);
-      expect(find.byIcon(Icons.check_circle), findsNWidgets(3));
-      expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(3));
-    });
+      setUpAll(() {
+          MemoStoreLocalSaver.constructorHook = (memoStore, path) {
+            return MemoStoreMockLocalSaver(memoStore, path);
+          };
+      });
 
-    testWidgets('BindingTagsPage should add tags to memo.',
-        (WidgetTester tester) async {
-      final memo = Memo();
-      memo.text = 'This is a test.';
-      memo.tags = ['a', 'b', 'c'];
-      await init(tester, memo);
-      await tester.tap(find.text('d'));
-      await tester.pump();
-      expect(find.byIcon(Icons.check_circle), findsNWidgets(4));
-      expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(2));
-    });
+      tearDownAll(() {
+          MemoStoreLocalSaver.constructorHook = null;
+      });
 
-    testWidgets('BindingTagsPage should remove tags from memo.',
+      testWidgets('BindingTagsPage should have specified widgets.',
         (WidgetTester tester) async {
-      final memo = Memo();
-      memo.text = 'This is a test.';
-      memo.tags = ['a', 'b', 'c'];
-      await init(tester, memo);
-      await tester.tap(find.text('a'));
-      await tester.pump();
-      expect(find.byIcon(Icons.check_circle), findsNWidgets(2));
-      expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(4));
-    });
+          final memo = Memo();
+          memo.text = 'This is a test.';
+          memo.tags = ['a', 'b', 'c'];
+          await init(tester, memo);
+          expect(find.text('a'), findsOneWidget);
+          expect(find.text('b'), findsOneWidget);
+          expect(find.text('c'), findsOneWidget);
+          expect(find.text('d'), findsOneWidget);
+          expect(find.text('e'), findsOneWidget);
+          expect(find.text('f'), findsOneWidget);
+          expect(find.byIcon(Icons.check_circle), findsNWidgets(3));
+          expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(3));
+      });
 
-    MemoStoreLocalSaver.constructorHook = null;
+      testWidgets('BindingTagsPage should add tags to memo.',
+        (WidgetTester tester) async {
+          final memo = Memo();
+          memo.text = 'This is a test.';
+          memo.tags = ['a', 'b', 'c'];
+          await init(tester, memo);
+          await tester.tap(find.text('d'));
+          await tester.pump();
+          expect(find.byIcon(Icons.check_circle), findsNWidgets(4));
+          expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(2));
+      });
+
+      testWidgets('BindingTagsPage should remove tags from memo.',
+        (WidgetTester tester) async {
+          final memo = Memo();
+          memo.text = 'This is a test.';
+          memo.tags = ['a', 'b', 'c'];
+          await init(tester, memo);
+          await tester.tap(find.text('a'));
+          await tester.pump();
+          expect(find.byIcon(Icons.check_circle), findsNWidgets(2));
+          expect(find.byIcon(Icons.check_circle_outline), findsNWidgets(4));
+      });
   });
 }

--- a/test/editing_page_test.dart
+++ b/test/editing_page_test.dart
@@ -22,41 +22,45 @@ Future<void> init(WidgetTester tester, Memo? memo) async {
 }
 
 void main() {
-  MemoStoreLocalSaver.constructorHook = (memoStore, path) {
-    return MemoStoreMockLocalSaver(memoStore, path);
-  };
-
   group('EditingPage', () {
-    testWidgets(
+      setUpAll(() {
+          MemoStoreLocalSaver.constructorHook = (memoStore, path) {
+            return MemoStoreMockLocalSaver(memoStore, path);
+          };
+      });
+
+      tearDownAll(() {
+          MemoStoreLocalSaver.constructorHook = null;
+      });
+
+      testWidgets(
         'EditingPage should have specified widgets when adding a new memo.',
         (WidgetTester tester) async {
-      await init(tester, null);
-      expect(find.text('Add a new memo'), findsOneWidget);
-      expect(find.byIcon(Icons.done), findsOneWidget);
-    });
+          await init(tester, null);
+          expect(find.text('Add a new memo'), findsOneWidget);
+          expect(find.byIcon(Icons.done), findsOneWidget);
+      });
 
-    testWidgets(
+      testWidgets(
         'EditingPage should have specified widgets when editing a memo.',
         (WidgetTester tester) async {
-      final memo = Memo();
-      memo.text = 'This is a test.';
-      await init(tester, memo);
-      expect(find.text('Edit a memo'), findsOneWidget);
-      expect(find.text('This is a test.'), findsOneWidget);
-      expect(find.byIcon(Icons.done), findsOneWidget);
-    });
+          final memo = Memo();
+          memo.text = 'This is a test.';
+          await init(tester, memo);
+          expect(find.text('Edit a memo'), findsOneWidget);
+          expect(find.text('This is a test.'), findsOneWidget);
+          expect(find.byIcon(Icons.done), findsOneWidget);
+      });
 
-    testWidgets(
+      testWidgets(
         'EditingPage should update memo text when done button is pressed.',
         (WidgetTester tester) async {
-      final memo = Memo();
-      await init(tester, memo);
-      await tester.enterText(find.byType(TextField), 'This is a text');
-      await tester.tap(find.byIcon(Icons.done));
-      await tester.pump();
-      expect(memo.text, 'This is a text');
-    });
-
-    MemoStoreLocalSaver.constructorHook = null;
+          final memo = Memo();
+          await init(tester, memo);
+          await tester.enterText(find.byType(TextField), 'This is a text');
+          await tester.tap(find.byIcon(Icons.done));
+          await tester.pump();
+          expect(memo.text, 'This is a text');
+      });
   });
 }

--- a/test/editing_page_test.dart
+++ b/test/editing_page_test.dart
@@ -23,44 +23,44 @@ Future<void> init(WidgetTester tester, Memo? memo) async {
 
 void main() {
   group('EditingPage', () {
-      setUpAll(() {
-          MemoStoreLocalSaver.constructorHook = (memoStore, path) {
-            return MemoStoreMockLocalSaver(memoStore, path);
-          };
-      });
+    setUpAll(() {
+      MemoStoreLocalSaver.constructorHook = (memoStore, path) {
+        return MemoStoreMockLocalSaver(memoStore, path);
+      };
+    });
 
-      tearDownAll(() {
-          MemoStoreLocalSaver.constructorHook = null;
-      });
+    tearDownAll(() {
+      MemoStoreLocalSaver.constructorHook = null;
+    });
 
-      testWidgets(
+    testWidgets(
         'EditingPage should have specified widgets when adding a new memo.',
         (WidgetTester tester) async {
-          await init(tester, null);
-          expect(find.text('Add a new memo'), findsOneWidget);
-          expect(find.byIcon(Icons.done), findsOneWidget);
-      });
+      await init(tester, null);
+      expect(find.text('Add a new memo'), findsOneWidget);
+      expect(find.byIcon(Icons.done), findsOneWidget);
+    });
 
-      testWidgets(
+    testWidgets(
         'EditingPage should have specified widgets when editing a memo.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          memo.text = 'This is a test.';
-          await init(tester, memo);
-          expect(find.text('Edit a memo'), findsOneWidget);
-          expect(find.text('This is a test.'), findsOneWidget);
-          expect(find.byIcon(Icons.done), findsOneWidget);
-      });
+      final memo = Memo();
+      memo.text = 'This is a test.';
+      await init(tester, memo);
+      expect(find.text('Edit a memo'), findsOneWidget);
+      expect(find.text('This is a test.'), findsOneWidget);
+      expect(find.byIcon(Icons.done), findsOneWidget);
+    });
 
-      testWidgets(
+    testWidgets(
         'EditingPage should update memo text when done button is pressed.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          await init(tester, memo);
-          await tester.enterText(find.byType(TextField), 'This is a text');
-          await tester.tap(find.byIcon(Icons.done));
-          await tester.pump();
-          expect(memo.text, 'This is a text');
-      });
+      final memo = Memo();
+      await init(tester, memo);
+      await tester.enterText(find.byType(TextField), 'This is a text');
+      await tester.tap(find.byIcon(Icons.done));
+      await tester.pump();
+      expect(memo.text, 'This is a text');
+    });
   });
 }

--- a/test/searching_page_test.dart
+++ b/test/searching_page_test.dart
@@ -29,21 +29,20 @@ Future<void> init(WidgetTester tester) async {
 
 void main() {
   group('SearchingPage', () {
-      setUpAll(() {
-          Settings.sharedPreferencesCreatorHook = () async {
-            return MockSharedPreferencesWithCache();
-          };
-      });
+    setUpAll(() {
+      Settings.sharedPreferencesCreatorHook = () async {
+        return MockSharedPreferencesWithCache();
+      };
+    });
 
-      tearDownAll(() {
-          Settings.sharedPreferencesCreatorHook = null;
-      });
+    tearDownAll(() {
+      Settings.sharedPreferencesCreatorHook = null;
+    });
 
-      testWidgets('SearchingPage shoud have specified widgets.',
+    testWidgets('SearchingPage shoud have specified widgets.',
         (WidgetTester tester) async {
-          await init(tester);
-          expect(find.text('Search memos'), findsWidgets);
-
-      });
+      await init(tester);
+      expect(find.text('Search memos'), findsWidgets);
+    });
   });
 }

--- a/test/searching_page_test.dart
+++ b/test/searching_page_test.dart
@@ -29,16 +29,21 @@ Future<void> init(WidgetTester tester) async {
 
 void main() {
   group('SearchingPage', () {
-    testWidgets('SearchingPage shoud have specified widgets.',
+      setUpAll(() {
+          Settings.sharedPreferencesCreatorHook = () async {
+            return MockSharedPreferencesWithCache();
+          };
+      });
+
+      tearDownAll(() {
+          Settings.sharedPreferencesCreatorHook = null;
+      });
+
+      testWidgets('SearchingPage shoud have specified widgets.',
         (WidgetTester tester) async {
-      Settings.sharedPreferencesCreatorHook = () async {
-        return MockSharedPreferencesWithCache();
-      };
+          await init(tester);
+          expect(find.text('Search memos'), findsWidgets);
 
-      await init(tester);
-      expect(find.text('Search memos'), findsWidgets);
-
-      Settings.sharedPreferencesCreatorHook = null;
-    });
+      });
   });
 }

--- a/test/settings_page_test.dart
+++ b/test/settings_page_test.dart
@@ -23,17 +23,21 @@ Future<void> init(WidgetTester tester) async {
 
 void main() {
   group('SettingsPage', () {
-    Settings.sharedPreferencesCreatorHook = () async {
-      return MockSharedPreferencesWithCache();
-    };
+      setUpAll(() {
+          Settings.sharedPreferencesCreatorHook = () async {
+            return MockSharedPreferencesWithCache();
+          };
+      });
 
-    testWidgets('SettinsPage should have specified widgets.',
+      tearDownAll(() {
+          Settings.sharedPreferencesCreatorHook = null;
+      });
+
+      testWidgets('SettinsPage should have specified widgets.',
         (WidgetTester tester) async {
-      await init(tester);
-      expect(find.text('Settings'), findsOneWidget);
-      expect(find.text('Hide Google Drive synchronization'), findsOneWidget);
-    });
-
-    Settings.sharedPreferencesCreatorHook = null;
+          await init(tester);
+          expect(find.text('Settings'), findsOneWidget);
+          expect(find.text('Hide Google Drive synchronization'), findsOneWidget);
+      });
   });
 }

--- a/test/settings_page_test.dart
+++ b/test/settings_page_test.dart
@@ -23,21 +23,21 @@ Future<void> init(WidgetTester tester) async {
 
 void main() {
   group('SettingsPage', () {
-      setUpAll(() {
-          Settings.sharedPreferencesCreatorHook = () async {
-            return MockSharedPreferencesWithCache();
-          };
-      });
+    setUpAll(() {
+      Settings.sharedPreferencesCreatorHook = () async {
+        return MockSharedPreferencesWithCache();
+      };
+    });
 
-      tearDownAll(() {
-          Settings.sharedPreferencesCreatorHook = null;
-      });
+    tearDownAll(() {
+      Settings.sharedPreferencesCreatorHook = null;
+    });
 
-      testWidgets('SettinsPage should have specified widgets.',
+    testWidgets('SettinsPage should have specified widgets.',
         (WidgetTester tester) async {
-          await init(tester);
-          expect(find.text('Settings'), findsOneWidget);
-          expect(find.text('Hide Google Drive synchronization'), findsOneWidget);
-      });
+      await init(tester);
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.text('Hide Google Drive synchronization'), findsOneWidget);
+    });
   });
 }

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -7,71 +7,57 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('Settings', () {
-    test('Settings should be created', () {
-      expect(Settings(), isNotNull);
-    });
+      setUpAll(() {
+          Settings.sharedPreferencesCreatorHook = () async {
+            return MockSharedPreferencesWithCache();
+          };
+      });
 
-    test(
+      tearDownAll(() {
+          Settings.sharedPreferencesCreatorHook = null;
+      });
+
+      test('Settings should be created', () {
+          expect(Settings(), isNotNull);
+      });
+
+      test(
         'Settings.getSynchronizingHidden() should get whether synchronizing is hidden',
         () async {
-      Settings.sharedPreferencesCreatorHook = () async {
-        return MockSharedPreferencesWithCache();
-      };
+          final settings = Settings();
+          await settings.init();
+          final hidden = settings.getSynchronizingHidden();
+          expect(hidden, false);
+      });
 
-      final settings = Settings();
-      await settings.init();
-      final hidden = settings.getSynchronizingHidden();
-      expect(hidden, false);
-
-      Settings.sharedPreferencesCreatorHook = null;
-    });
-
-    test(
+      test(
         'Settings.setSynchronizingHidden() should set whether synchronizing is hidden',
         () async {
-      Settings.sharedPreferencesCreatorHook = () async {
-        return MockSharedPreferencesWithCache();
-      };
-
-      final settings = Settings();
-      await settings.init();
-      await settings.setSynchronizingHidden(true);
-      final hidden = settings.getSynchronizingHidden();
-      expect(hidden, true);
-
-      Settings.sharedPreferencesCreatorHook = null;
-    });
-
-    test('Settings.getTagScores() should get tag scores', () async {
-      Settings.sharedPreferencesCreatorHook = () async {
-        return MockSharedPreferencesWithCache();
-      };
-
-      final settings = Settings();
-      await settings.init();
-      final scores = settings.getTagScores();
-      expect(scores['a'], 1.0);
-      expect(scores['b'], 0.5);
-
-      Settings.sharedPreferencesCreatorHook = null;
-    });
-
-    test('Settings.setTagScores() should set tag scores', () async {
-      Settings.sharedPreferencesCreatorHook = () async {
-        return MockSharedPreferencesWithCache();
-      };
-
-      final settings = Settings();
-      await settings.init();
-      await settings.setTagScores({
-        'c': 1.0,
-        'd': 0.5,
+          final settings = Settings();
+          await settings.init();
+          await settings.setSynchronizingHidden(true);
+          final hidden = settings.getSynchronizingHidden();
+          expect(hidden, true);
       });
-      final scores = settings.getTagScores();
-      expect(scores['c'], 1.0);
-      expect(scores['d'], 0.5);
 
-      Settings.sharedPreferencesCreatorHook = null;
-    });
+      test('Settings.getTagScores() should get tag scores', () async {
+          final settings = Settings();
+          await settings.init();
+          final scores = settings.getTagScores();
+          expect(scores['a'], 1.0);
+          expect(scores['b'], 0.5);
+      });
+
+      test('Settings.setTagScores() should set tag scores', () async {
+          final settings = Settings();
+          await settings.init();
+          await settings.setTagScores({
+              'c': 1.0,
+              'd': 0.5,
+          });
+          final scores = settings.getTagScores();
+          expect(scores['c'], 1.0);
+          expect(scores['d'], 0.5);
+      });
   });
 }

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -7,57 +7,57 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('Settings', () {
-      setUpAll(() {
-          Settings.sharedPreferencesCreatorHook = () async {
-            return MockSharedPreferencesWithCache();
-          };
-      });
+    setUpAll(() {
+      Settings.sharedPreferencesCreatorHook = () async {
+        return MockSharedPreferencesWithCache();
+      };
+    });
 
-      tearDownAll(() {
-          Settings.sharedPreferencesCreatorHook = null;
-      });
+    tearDownAll(() {
+      Settings.sharedPreferencesCreatorHook = null;
+    });
 
-      test('Settings should be created', () {
-          expect(Settings(), isNotNull);
-      });
+    test('Settings should be created', () {
+      expect(Settings(), isNotNull);
+    });
 
-      test(
+    test(
         'Settings.getSynchronizingHidden() should get whether synchronizing is hidden',
         () async {
-          final settings = Settings();
-          await settings.init();
-          final hidden = settings.getSynchronizingHidden();
-          expect(hidden, false);
-      });
+      final settings = Settings();
+      await settings.init();
+      final hidden = settings.getSynchronizingHidden();
+      expect(hidden, false);
+    });
 
-      test(
+    test(
         'Settings.setSynchronizingHidden() should set whether synchronizing is hidden',
         () async {
-          final settings = Settings();
-          await settings.init();
-          await settings.setSynchronizingHidden(true);
-          final hidden = settings.getSynchronizingHidden();
-          expect(hidden, true);
-      });
+      final settings = Settings();
+      await settings.init();
+      await settings.setSynchronizingHidden(true);
+      final hidden = settings.getSynchronizingHidden();
+      expect(hidden, true);
+    });
 
-      test('Settings.getTagScores() should get tag scores', () async {
-          final settings = Settings();
-          await settings.init();
-          final scores = settings.getTagScores();
-          expect(scores['a'], 1.0);
-          expect(scores['b'], 0.5);
-      });
+    test('Settings.getTagScores() should get tag scores', () async {
+      final settings = Settings();
+      await settings.init();
+      final scores = settings.getTagScores();
+      expect(scores['a'], 1.0);
+      expect(scores['b'], 0.5);
+    });
 
-      test('Settings.setTagScores() should set tag scores', () async {
-          final settings = Settings();
-          await settings.init();
-          await settings.setTagScores({
-              'c': 1.0,
-              'd': 0.5,
-          });
-          final scores = settings.getTagScores();
-          expect(scores['c'], 1.0);
-          expect(scores['d'], 0.5);
+    test('Settings.setTagScores() should set tag scores', () async {
+      final settings = Settings();
+      await settings.init();
+      await settings.setTagScores({
+        'c': 1.0,
+        'd': 0.5,
       });
+      final scores = settings.getTagScores();
+      expect(scores['c'], 1.0);
+      expect(scores['d'], 0.5);
+    });
   });
 }

--- a/test/viewing_page_test.dart
+++ b/test/viewing_page_test.dart
@@ -31,63 +31,63 @@ Future<void> init(WidgetTester tester, Memo memo) async {
 
 void main() {
   group('ViewingPage', () {
-      setUpAll(() {
-          MemoStoreLocalSaver.constructorHook = (memoStore, path) {
-            return MemoStoreMockLocalSaver(memoStore, path);
-          };
-          Settings.sharedPreferencesCreatorHook = () async {
-            return MockSharedPreferencesWithCache();
-          };
-      });
+    setUpAll(() {
+      MemoStoreLocalSaver.constructorHook = (memoStore, path) {
+        return MemoStoreMockLocalSaver(memoStore, path);
+      };
+      Settings.sharedPreferencesCreatorHook = () async {
+        return MockSharedPreferencesWithCache();
+      };
+    });
 
-      tearDownAll(() {
-          Settings.sharedPreferencesCreatorHook = null;
-          MemoStoreLocalSaver.constructorHook = null;
-      });
-      
-      // TODO: Add tests fo TinyMarkdown viewing mode.
-      testWidgets('ViewingPage should have specified widgets.',
+    tearDownAll(() {
+      Settings.sharedPreferencesCreatorHook = null;
+      MemoStoreLocalSaver.constructorHook = null;
+    });
+
+    // TODO: Add tests fo TinyMarkdown viewing mode.
+    testWidgets('ViewingPage should have specified widgets.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          await init(tester, memo);
-          expect(find.byIcon(Icons.close), findsOneWidget);
-          expect(find.byIcon(Icons.share), findsOneWidget);
-          expect(find.byIcon(Icons.delete), findsOneWidget);
-          expect(find.byIcon(Icons.edit), findsOneWidget);
-          expect(find.textContaining('Test'), findsWidgets);
-          expect(find.textContaining('This is a test.'), findsOneWidget);
-          expect(find.textContaining('Updated:'), findsOneWidget);
-          expect(find.textContaining('Tags:'), findsOneWidget);
-      });
+      final memo = Memo();
+      await init(tester, memo);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+      expect(find.byIcon(Icons.share), findsOneWidget);
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+      expect(find.textContaining('Test'), findsWidgets);
+      expect(find.textContaining('This is a test.'), findsOneWidget);
+      expect(find.textContaining('Updated:'), findsOneWidget);
+      expect(find.textContaining('Tags:'), findsOneWidget);
+    });
 
-      testWidgets(
+    testWidgets(
         'ViewingPage should show confirmation dialog when user taps delete button.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          await init(tester, memo);
-          await tester.tap(find.byIcon(Icons.delete));
-          await tester.pump();
-          expect(find.text('Delete this memo?'), findsOneWidget);
-      });
+      final memo = Memo();
+      await init(tester, memo);
+      await tester.tap(find.byIcon(Icons.delete));
+      await tester.pump();
+      expect(find.text('Delete this memo?'), findsOneWidget);
+    });
 
-      testWidgets(
+    testWidgets(
         'ViewingPage should show EditingPage when user taps edit button.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          await init(tester, memo);
-          await tester.tap(find.byIcon(Icons.edit));
-          await tester.pump();
-          expect(find.text('Edit a memo'), findsOneWidget);
-      });
+      final memo = Memo();
+      await init(tester, memo);
+      await tester.tap(find.byIcon(Icons.edit));
+      await tester.pump();
+      expect(find.text('Edit a memo'), findsOneWidget);
+    });
 
-      testWidgets(
+    testWidgets(
         'ViewingPage should show EditingPage when user taps edit button.',
         (WidgetTester tester) async {
-          final memo = Memo();
-          await init(tester, memo);
-          await tester.tap(find.textContaining('Tags:'));
-          await tester.pump();
-          expect(find.text('Bind tags'), findsOneWidget);
-      });
+      final memo = Memo();
+      await init(tester, memo);
+      await tester.tap(find.textContaining('Tags:'));
+      await tester.pump();
+      expect(find.text('Bind tags'), findsOneWidget);
+    });
   });
 }

--- a/test/viewing_page_test.dart
+++ b/test/viewing_page_test.dart
@@ -30,60 +30,64 @@ Future<void> init(WidgetTester tester, Memo memo) async {
 }
 
 void main() {
-  MemoStoreLocalSaver.constructorHook = (memoStore, path) {
-    return MemoStoreMockLocalSaver(memoStore, path);
-  };
-  Settings.sharedPreferencesCreatorHook = () async {
-    return MockSharedPreferencesWithCache();
-  };
-
   group('ViewingPage', () {
-    // TODO: Add tests fo TinyMarkdown viewing mode.
-    testWidgets('ViewingPage should have specified widgets.',
-        (WidgetTester tester) async {
-      final memo = Memo();
-      await init(tester, memo);
-      expect(find.byIcon(Icons.close), findsOneWidget);
-      expect(find.byIcon(Icons.share), findsOneWidget);
-      expect(find.byIcon(Icons.delete), findsOneWidget);
-      expect(find.byIcon(Icons.edit), findsOneWidget);
-      expect(find.textContaining('Test'), findsWidgets);
-      expect(find.textContaining('This is a test.'), findsOneWidget);
-      expect(find.textContaining('Updated:'), findsOneWidget);
-      expect(find.textContaining('Tags:'), findsOneWidget);
-    });
+      setUpAll(() {
+          MemoStoreLocalSaver.constructorHook = (memoStore, path) {
+            return MemoStoreMockLocalSaver(memoStore, path);
+          };
+          Settings.sharedPreferencesCreatorHook = () async {
+            return MockSharedPreferencesWithCache();
+          };
+      });
 
-    testWidgets(
+      tearDownAll(() {
+          Settings.sharedPreferencesCreatorHook = null;
+          MemoStoreLocalSaver.constructorHook = null;
+      });
+      
+      // TODO: Add tests fo TinyMarkdown viewing mode.
+      testWidgets('ViewingPage should have specified widgets.',
+        (WidgetTester tester) async {
+          final memo = Memo();
+          await init(tester, memo);
+          expect(find.byIcon(Icons.close), findsOneWidget);
+          expect(find.byIcon(Icons.share), findsOneWidget);
+          expect(find.byIcon(Icons.delete), findsOneWidget);
+          expect(find.byIcon(Icons.edit), findsOneWidget);
+          expect(find.textContaining('Test'), findsWidgets);
+          expect(find.textContaining('This is a test.'), findsOneWidget);
+          expect(find.textContaining('Updated:'), findsOneWidget);
+          expect(find.textContaining('Tags:'), findsOneWidget);
+      });
+
+      testWidgets(
         'ViewingPage should show confirmation dialog when user taps delete button.',
         (WidgetTester tester) async {
-      final memo = Memo();
-      await init(tester, memo);
-      await tester.tap(find.byIcon(Icons.delete));
-      await tester.pump();
-      expect(find.text('Delete this memo?'), findsOneWidget);
-    });
+          final memo = Memo();
+          await init(tester, memo);
+          await tester.tap(find.byIcon(Icons.delete));
+          await tester.pump();
+          expect(find.text('Delete this memo?'), findsOneWidget);
+      });
 
-    testWidgets(
+      testWidgets(
         'ViewingPage should show EditingPage when user taps edit button.',
         (WidgetTester tester) async {
-      final memo = Memo();
-      await init(tester, memo);
-      await tester.tap(find.byIcon(Icons.edit));
-      await tester.pump();
-      expect(find.text('Edit a memo'), findsOneWidget);
-    });
+          final memo = Memo();
+          await init(tester, memo);
+          await tester.tap(find.byIcon(Icons.edit));
+          await tester.pump();
+          expect(find.text('Edit a memo'), findsOneWidget);
+      });
 
-    testWidgets(
+      testWidgets(
         'ViewingPage should show EditingPage when user taps edit button.',
         (WidgetTester tester) async {
-      final memo = Memo();
-      await init(tester, memo);
-      await tester.tap(find.textContaining('Tags:'));
-      await tester.pump();
-      expect(find.text('Bind tags'), findsOneWidget);
-    });
-
-    Settings.sharedPreferencesCreatorHook = null;
-    MemoStoreLocalSaver.constructorHook = null;
+          final memo = Memo();
+          await init(tester, memo);
+          await tester.tap(find.textContaining('Tags:'));
+          await tester.pump();
+          expect(find.text('Bind tags'), findsOneWidget);
+      });
   });
 }


### PR DESCRIPTION
Added setUpAll() and tearDownAll() callings for tests.
This closes #399.
